### PR TITLE
Fix tags layout on stacks section

### DIFF
--- a/app/pages/projects/overview.vue
+++ b/app/pages/projects/overview.vue
@@ -318,7 +318,7 @@
           <div>
             <h3 class="font-bold mb-3 dark:text-gray-200">Stack</h3>
 
-            <div class="flex items-center justify-start gap-4">
+            <div class="flex flex-wrap gap-4">
               <span
                 v-for="tech in selectedProject?.details.stacks"
                 :key="tech"


### PR DESCRIPTION
### Descrição

Foi identificado um erro de layout na seção de Stack. Basicamente, a lista de tags não estavam quebrando uma linha para baixo.

### Screenshots

| Antes | Depois |
|-------|--------|
| <img width="415" height="815" alt="Captura de Tela 2026-02-05 às 21 47 09" src="https://github.com/user-attachments/assets/50d9a48c-535d-463f-b7d6-c53562e74be9" /> | <img width="486" height="815" alt="Captura de Tela 2026-02-05 às 21 46 18" src="https://github.com/user-attachments/assets/2e97d6b8-cc7d-429b-88f9-ad2c13feb880" />

